### PR TITLE
Add GitHub Actions CI for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # b4m-necromancer - revive your old scanner with Raspberry Pi ZERO 2
 
+[![CI](https://github.com/b4m-oss/necromancer/actions/workflows/ci.yml/badge.svg)](https://github.com/b4m-oss/necromancer/actions/workflows/ci.yml)
+
 [日本語版](./README_ja.md)
 
 This system is a small solution to automate document scanning from a numeric keypad.  

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,5 +1,7 @@
 # b4m-necromancer - revive your old scanner with Raspberry Pi ZERO 2
 
+[![CI](https://github.com/b4m-oss/necromancer/actions/workflows/ci.yml/badge.svg)](https://github.com/b4m-oss/necromancer/actions/workflows/ci.yml)
+
 [English](./README.md)
 
 このシステムは、テンキーパッドからの入力によってドキュメントスキャンを自動実行するためのソリューションです。


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` (push + pull_request, ubuntu-latest, Python 3.11) running `pip install -e ".[dev]"` then `pytest -q`
- Add CI badges to `README.md` and `README_ja.md`

Closes #21

## Test plan
- [ ] Confirm CI workflow runs on this PR and is green
- [ ] Locally: `make test` (67 passed)
- [ ] Badge URLs resolve to the Actions workflow page


Made with [Cursor](https://cursor.com)