### PR TITLE
Add one-liner install path for Raspberry Pi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,12 @@ VENV_BIN := $(VENV)/bin
 PYTEST := $(VENV_BIN)/pytest
 DOCKER_COMPOSE ?= docker compose
 
-.PHONY: help venv install-dev test test-cov coverage-html docker-build docker-test clean
+.PHONY: help venv install-dev install-pi test test-cov coverage-html docker-build docker-test clean
 
 help:
 	@echo "Targets:"
 	@echo "  make install-dev    Create .venv and pip install -e \".[dev]\""
+	@echo "  make install-pi     Run ./install.sh (Raspberry Pi deploy via app/install.sh)"
 	@echo "  make test           Run pytest on host"
 	@echo "  make test-cov       Run pytest with coverage (app/lib, terminal report)"
 	@echo "  make coverage-html  Same as test-cov, plus htmlcov/ report"
@@ -34,6 +35,9 @@ venv:
 
 install-dev: venv
 	$(VENV_BIN)/pip install -e ".[dev]"
+
+install-pi:
+	./install.sh
 
 test: $(PYTEST)
 	$(PYTEST) -q

--- a/README.md
+++ b/README.md
@@ -39,17 +39,32 @@ As a result, SANE was discovered, and the idea came up to drive the scanner from
 
 ### Automatic installation
 
-In the following steps, we assume that the repository is cloned to `~/b4m-necromancer`.
+On a Raspberry Pi, clone the repo and run the root installer (delegates to `app/install.sh`).
 
-1. Clone the repository on your Raspberry Pi.
-2. Change into the `app` directory and run the install script.
+**Recommended** (after the `v0.3.0` release tag exists):
 
 ```bash
-git clone https://github.com/b4m-oss/b4m-necromancer.git ~/b4m-necromancer
-cd ~/b4m-necromancer/app
-chmod +x install.sh
-./install.sh
+git clone --branch v0.3.0 https://github.com/b4m-oss/necromancer.git ~/necromancer
+cd ~/necromancer && ./install.sh
 ```
+
+Until the tag is published, use a development branch instead:
+
+```bash
+git clone --branch dev-v0.3.0 https://github.com/b4m-oss/necromancer.git ~/necromancer
+# or: --branch main
+cd ~/necromancer && ./install.sh
+```
+
+You can also run `make install-pi` from the repository root (same as `./install.sh`).
+
+**Optional** (from a cloned repository root; prefers the tagged script):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/b4m-oss/necromancer/v0.3.0/install.sh | bash
+```
+
+After install, copy `~/app/config/upload.example.json` → `~/app/config/upload.json` and edit credentials (do not commit secrets). See [Setup and configuration](./docs/en/setup_config.md).
 
 ### Manual installation
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -39,17 +39,32 @@
 
 ### 自動インストール
 
-以下では、リポジトリを `~/b4m-necromancer` にクローンする前提で説明します。
+Raspberry Pi 上でリポジトリをクローンし、ルートのインストーラを実行します（内部で `app/install.sh` に委譲します）。
 
-1. Raspberry Pi 上でリポジトリをクローンします
-2. `app` ディレクトリに移動してインストールスクリプトを実行します
+**推奨**（リリースタグ `v0.3.0` 公開後）:
 
 ```bash
-git clone https://github.com/b4m-oss/b4m-necromancer.git ~/b4m-necromancer
-cd ~/b4m-necromancer/app
-chmod +x install.sh
-./install.sh
+git clone --branch v0.3.0 https://github.com/b4m-oss/necromancer.git ~/necromancer
+cd ~/necromancer && ./install.sh
 ```
+
+タグがまだ無い場合は、開発ブランチを使ってください:
+
+```bash
+git clone --branch dev-v0.3.0 https://github.com/b4m-oss/necromancer.git ~/necromancer
+# または: --branch main
+cd ~/necromancer && ./install.sh
+```
+
+リポジトリルートから `make install-pi` でも同じ処理になります（`./install.sh` 相当）。
+
+**任意**（クローン済みリポジトリのルートから。タグ付きスクリプトを優先）:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/b4m-oss/necromancer/v0.3.0/install.sh | bash
+```
+
+インストール後は `~/app/config/upload.example.json` を `~/app/config/upload.json` にコピーして認証情報を編集してください（秘密情報はコミットしないでください）。詳細は [セットアップと設定](./docs/ja/setup_config.md) を参照。
 
 ### 手動インストール
 

--- a/app/install.sh
+++ b/app/install.sh
@@ -95,8 +95,18 @@ sudo systemctl daemon-reload
 sudo systemctl enable scanner_service.service
 
 echo "Installation finished!"
-echo "To start the service: sudo systemctl start scanner_service.service"
-echo "To check status:      sudo systemctl status scanner_service.service"
+echo ""
+echo "Next steps:"
+echo "  1. Copy upload settings (keep secrets out of git):"
+echo "       cp ${APP_DST_DIR}/config/upload.example.json ${APP_DST_DIR}/config/upload.json"
+echo "     Then edit upload.json with your credentials."
+echo "  2. Review scanner/mode settings under ${APP_DST_DIR}/config/"
+echo "  3. Start the service:"
+echo "       sudo systemctl start scanner_service.service"
+echo "     Check status:"
+echo "       sudo systemctl status scanner_service.service"
+echo "  4. Optional dry-run (open a new shell, or source ~/.bashrc / ~/.zshrc first):"
+echo "       necro --dry-run check"
 echo ""
 echo "Start the service now? [y/N]"
 read -r start_service

--- a/docs/en/manual_installation.md
+++ b/docs/en/manual_installation.md
@@ -1,11 +1,12 @@
 # b4m-necromancer Manual Installation
 
+Prefer the automatic path when possible: clone the repo and run `./install.sh` (or `make install-pi`) from the repository root. Use the steps below only if you need a fully manual setup.
+
 1. Install required packages
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y python3-pip python3-evdev sane-utils
-pip3 install evdev pillow
+sudo apt-get install -y python3-venv python3-pip python3-evdev sane-utils zlib1g-dev libjpeg-dev
 ```
 
 2. Create log directory
@@ -18,35 +19,46 @@ sudo chown $USER:$USER /var/log/scanner
 3. Deploy application files
 
 ```bash
-git clone https://github.com/b4m-oss/b4m-necromancer.git ~/b4m-necromancer
+git clone --branch v0.3.0 https://github.com/b4m-oss/necromancer.git ~/necromancer
+# Until the tag exists: --branch dev-v0.3.0 or --branch main
 mkdir -p ~/app
-cp -r ~/b4m-necromancer/app/* ~/app/
+cp -r ~/necromancer/app/* ~/app/
 mkdir -p ~/app/tmp
 ```
 
-4. Set up systemd service
+4. Create a Python virtual environment and install dependencies
 
 ```bash
-sudo cp ~/b4m-necromancer/app/scanner_service.service /etc/systemd/system/
+python3 -m venv ~/app/venv
+~/app/venv/bin/pip install --upgrade pip
+~/app/venv/bin/pip install -r ~/app/requirements.txt
+```
+
+5. Set up systemd service
+
+```bash
+sudo cp ~/necromancer/app/scanner_service.service /etc/systemd/system/
 
 # Adjust user / group / working directory for your environment
-sudo sed -i "s/User=kohki/User=$USER/g" /etc/systemd/system/scanner_service.service
-sudo sed -i "s/Group=kohki/Group=$USER/g" /etc/systemd/system/scanner_service.service
-sudo sed -i "s|WorkingDirectory=/home/kohki/app|WorkingDirectory=/home/$USER/app|g" /etc/systemd/system/scanner_service.service
-sudo sed -i "s|ExecStart=/home/kohki/myscan/bin/python3 /home/kohki/app/keypad_daemon.py|ExecStart=/usr/bin/python3 /home/$USER/app/keypad_daemon.py|g" /etc/systemd/system/scanner_service.service
-sudo sed -i '/^Environment="PYTHONPATH=/d' /etc/systemd/system/scanner_service.service
+sudo sed -i "s/User=__USER__/User=$USER/g" /etc/systemd/system/scanner_service.service
+sudo sed -i "s/Group=__USER__/Group=$USER/g" /etc/systemd/system/scanner_service.service
+sudo sed -i "s|__APP_WORKDIR__|${HOME}/app|g" /etc/systemd/system/scanner_service.service
+sudo sed -i "s|^ExecStart=/usr/bin/python3 |ExecStart=${HOME}/app/venv/bin/python |g" /etc/systemd/system/scanner_service.service
 ```
 
-5. Make scripts executable
+6. Make scripts executable
 
 ```bash
-chmod +x ~/b4m-necromancer/app/keypad_daemon.py
-chmod +x ~/b4m-necromancer/app/lib/scan.py
+chmod +x ~/app/keypad_daemon.py
+chmod +x ~/app/lib/scan.py
 ```
 
-6. Enable and start the service
+7. Copy upload settings and enable the service
 
 ```bash
+cp ~/app/config/upload.example.json ~/app/config/upload.json
+# Edit upload.json with your credentials (do not commit secrets)
+
 sudo systemctl daemon-reload
 sudo systemctl enable scanner_service.service
 sudo systemctl start scanner_service.service
@@ -55,4 +67,3 @@ sudo systemctl start scanner_service.service
 -------
 
 Done.
-

--- a/docs/ja/manual_installation.md
+++ b/docs/ja/manual_installation.md
@@ -1,10 +1,12 @@
 # b4m-necromancer Manual Installation
 
+可能なら自動インストールを推奨します。リポジトリをクローンし、ルートで `./install.sh`（または `make install-pi`）を実行してください。以下は手動セットアップが必要な場合のみ使います。
+
 1. 必要なパッケージをインストールします
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y python3-pip python3-evdev sane-utils
+sudo apt-get install -y python3-venv python3-pip python3-evdev sane-utils zlib1g-dev libjpeg-dev
 ```
 
 2. ログディレクトリを作成します
@@ -17,9 +19,10 @@ sudo chown $USER:$USER /var/log/scanner
 3. アプリケーションファイルを配置します
 
 ```bash
-git clone https://github.com/b4m-oss/b4m-necromancer.git ~/b4m-necromancer
+git clone --branch v0.3.0 https://github.com/b4m-oss/necromancer.git ~/necromancer
+# タグ未公開時: --branch dev-v0.3.0 または --branch main
 mkdir -p ~/app
-cp -r ~/b4m-necromancer/app/* ~/app/
+cp -r ~/necromancer/app/* ~/app/
 mkdir -p ~/app/tmp
 ```
 
@@ -34,26 +37,28 @@ python3 -m venv ~/app/venv
 5. systemdサービスをセットアップします
 
 ```bash
-sudo cp ~/b4m-necromancer/app/scanner_service.service /etc/systemd/system/
+sudo cp ~/necromancer/app/scanner_service.service /etc/systemd/system/
 
 # ユーザー名・パスを現在の環境に合わせて修正
-sudo sed -i "s/User=kohki/User=$USER/g" /etc/systemd/system/scanner_service.service
-sudo sed -i "s/Group=kohki/Group=$USER/g" /etc/systemd/system/scanner_service.service
-sudo sed -i "s|WorkingDirectory=/home/kohki/app|WorkingDirectory=/home/$USER/app|g" /etc/systemd/system/scanner_service.service
-sudo sed -i "s|ExecStart=/home/kohki/myscan/bin/python3 /home/kohki/app/keypad_daemon.py|ExecStart=/home/$USER/app/venv/bin/python /home/$USER/app/keypad_daemon.py|g" /etc/systemd/system/scanner_service.service
-sudo sed -i '/^Environment="PYTHONPATH=/d' /etc/systemd/system/scanner_service.service
+sudo sed -i "s/User=__USER__/User=$USER/g" /etc/systemd/system/scanner_service.service
+sudo sed -i "s/Group=__USER__/Group=$USER/g" /etc/systemd/system/scanner_service.service
+sudo sed -i "s|__APP_WORKDIR__|${HOME}/app|g" /etc/systemd/system/scanner_service.service
+sudo sed -i "s|^ExecStart=/usr/bin/python3 |ExecStart=${HOME}/app/venv/bin/python |g" /etc/systemd/system/scanner_service.service
 ```
 
 6. 実行権限を設定します
 
 ```bash
-chmod +x ~/b4m-necromancer/app/keypad_daemon.py
-chmod +x ~/b4m-necromancer/app/lib/scan.py
+chmod +x ~/app/keypad_daemon.py
+chmod +x ~/app/lib/scan.py
 ```
 
-7. サービスを有効化して開始します
+7. アップロード設定をコピーし、サービスを有効化して開始します
 
 ```bash
+cp ~/app/config/upload.example.json ~/app/config/upload.json
+# upload.json を編集して認証情報を設定（秘密情報はコミットしない）
+
 sudo systemctl daemon-reload
 sudo systemctl enable scanner_service.service
 sudo systemctl start scanner_service.service

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Thin wrapper: run from the necromancer repository root to install on a Pi.
+# Delegates to app/install.sh (systemd / venv / apt setup).
+
+set -e
+
+resolve_app_install() {
+    local script_dir=""
+    # Prefer the directory of this script when it is a real file (./install.sh).
+    if [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        if [ -f "${script_dir}/app/install.sh" ]; then
+            echo "${script_dir}/app/install.sh"
+            return 0
+        fi
+    fi
+    # Fallback for curl|bash from a cloned repo root (cwd must be the repo).
+    if [ -f "$(pwd)/app/install.sh" ]; then
+        echo "$(pwd)/app/install.sh"
+        return 0
+    fi
+    return 1
+}
+
+APP_INSTALL="$(resolve_app_install)" || {
+    echo "ERROR: app/install.sh not found." >&2
+    echo "Clone the repository and run this script from the repository root:" >&2
+    echo "  git clone --branch v0.3.0 https://github.com/b4m-oss/necromancer.git ~/necromancer" >&2
+    echo "  cd ~/necromancer && ./install.sh" >&2
+    echo "(Until the v0.3.0 tag exists, use --branch dev-v0.3.0 or --branch main.)" >&2
+    exit 1
+}
+
+exec bash "$APP_INSTALL" "$@"


### PR DESCRIPTION
## Summary
- Add root `install.sh` that delegates to `app/install.sh` (with clear errors if run outside the repo)
- Improve post-install next steps in `app/install.sh` (upload.example.json → upload.json, systemctl, optional `necro --dry-run check`)
- Add `make install-pi` → `./install.sh`
- Update README (EN/JA) and manual installation docs with one-liner clone + install, `b4m-oss/necromancer` URLs, and note that `v0.3.0` tag is for release (use `dev-v0.3.0` / `main` until then)

Closes #22

## Test plan
- [x] `bash -n install.sh app/install.sh`
- [ ] Follow README clone + `./install.sh` on a Pi (or review path resolution)
- [ ] Confirm upload.example.json → upload.json guidance appears after install
- [ ] Optional: `make install-pi` from repo root

## Notes
- Independent of #21 / PR #29 (CI); no intentional conflict with `.github/`
- Tag `v0.3.0` / version bump left for a separate release step


Made with [Cursor](https://cursor.com)