### PR TITLE
Run CI only on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- GitHub Actions CI のトリガから \`push\` を外し、\`pull_request\` のみにする
- 同一変更で CI が二重に走るのを防ぐ

## Test plan
- [x] この PR で CI が 1 ジョブだけ走ることを確認
- [x] push のみ（PR なし）では CI が走らないことを確認（任意）


Made with [Cursor](https://cursor.com)